### PR TITLE
Fix kafka server start issue

### DIFF
--- a/kafka/install.sh
+++ b/kafka/install.sh
@@ -18,7 +18,10 @@ curl -LO $kafkaurl/$kafkafile
 tar xvzf ./$kafkafile|| exit 1
 rm -f ./$kafkafile
 ln -s $kafka kafka
+
+# Create and set zookeeper data directory in configuration file
 mkdir $kafka/zookeeper_data
+sed -e 's/dataDir=.*/dataDir=zookeeper_data/' -i $kafka/config/zookeeper.properties
 
 # Try to  add Kafka IP address to config file
 # Fist get it via the user configuration - if it exist

--- a/kafka/install.sh
+++ b/kafka/install.sh
@@ -11,13 +11,14 @@ sudo pip3 install argparse
 
 kafka=kafka_2.13-2.5.0
 kafkafile=$kafka.tgz
-kafkaurl=http://ftp.download-by.net/apache/kafka/2.5.0/
+kafkaurl=https://archive.apache.org/dist/kafka/2.5.0
 curl -LO $kafkaurl/$kafkafile
 #TODO: ensure download is successful
 
 tar xvzf ./$kafkafile|| exit 1
 rm -f ./$kafkafile
 ln -s $kafka kafka
+mkdir $kafka/zookeeper_data
 
 # Try to  add Kafka IP address to config file
 # Fist get it via the user configuration - if it exist

--- a/kafka/start_kafka.sh
+++ b/kafka/start_kafka.sh
@@ -11,6 +11,9 @@ pushd kafka
 echo "Starting Zookeeper"
 ./bin/zookeeper-server-start.sh -daemon ./config/zookeeper.properties
 
+echo "Wait 10s for initialisation"
+sleep 10
+
 echo "Starting Kafka"
 ./bin/kafka-server-start.sh -daemon ../server.config
 

--- a/kafka/stop_kafka.sh
+++ b/kafka/stop_kafka.sh
@@ -10,5 +10,8 @@ pushd kafka/bin
 echo "Stopping Kafka"
 ./kafka-server-stop.sh
 
+echo "Wait 10s for termination"
+sleep 10
+
 echo "Stopping Zookeeper"
 ./zookeeper-server-stop.sh


### PR DESCRIPTION
- Fix URL for downloading Kafka 2.5.0 (the version we are currently using internally)
- Add `sleep` between ZooKeeper and Kafka initialisation and termination
- Create directory for ZooKeeper data (it was using the default in /tmp)